### PR TITLE
Publish DAG breaking on Airflow

### DIFF
--- a/dags/customer_metrics.py
+++ b/dags/customer_metrics.py
@@ -60,15 +60,15 @@ def customer_metrics():
     def quality_checks_done():
         return True
 
-    # publish = DbtTaskGroup(
-    #     group_id='publish',
-    #     project_config=DBT_PROJECT_CONFIG,
-    #     profile_config=DBT_CONFIG,
-    #     render_config=RenderConfig(
-    #         load_method=LoadMode.DBT_LS,
-    #         select=['path:models']
-    #     )
-    # )    
+    publish = DbtTaskGroup(
+        group_id='publish',
+        project_config=DBT_PROJECT_CONFIG,
+        profile_config=DBT_CONFIG,
+        render_config=RenderConfig(
+            load_method=LoadMode.DBT_LS,
+            select=['path:models']
+        )
+    )    
 
     chain(
         [load_customer_transactions_raw, load_labeled_transactions_raw],
@@ -76,7 +76,7 @@ def customer_metrics():
         airbyte_jobs_done(),
         [audit_customer_transactions(), audit_labeled_transactions()],
         quality_checks_done(),
-        # publish,
+        publish
     )
 
 customer_metrics()

--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -60,12 +60,23 @@ def customer_metrics_test_dag():
     def quality_checks_done():
         return True
     
+    # publish = DbtTaskGroup(
+    #     group_id='publish',
+    #     project_config=DBT_PROJECT_CONFIG,
+    #     profile_config=DBT_CONFIG,
+    #     render_config=RenderConfig(
+    #         load_method=LoadMode.DBT_LS,
+    #         select=['path:models']
+    #     )
+    # )   
+        
     chain(
         [load_customer_transactions_raw, load_labeled_transactions_raw], 
         write_to_staging,
         airbyte_jobs_done(),
         [audit_customer_transactions(), audit_labeled_transactions()],
-        quality_checks_done()
+        quality_checks_done(),
+        # publish
     )
 
 customer_metrics_test_dag()


### PR DESCRIPTION
# Customer Metrics DAG breaking on Apache Airflow
## Description of the issue
During the Introduction to Airbyte course on Udemy by Marc Lamberti, in the final Fraud project, I noticed that DAG is breaking when I was adding the publish task.
Here, I try to work on a duplicate and through deduction conclude to where is the issue exactly.
## Example 1
Here I use a duplicate of the DAG file, where I comment the publish part. As we can see, DAG appears, while the original DAG of `customer_metrics` DAG doesn't.
![image](https://github.com/geziogas/airbyte_project/assets/7390196/3e619f7c-1107-49b4-a9d9-7ef63ec72d62)
## Example 2
Just to verify my hypothesis about where is the issue, I tried here to also comment the publish part on the original `customer_metrics` DAG. As we can see, its corresponding DAG appears in the Airflow UI
![image](https://github.com/geziogas/airbyte_project/assets/7390196/5100d425-70a7-4fc6-a3d3-bd9cb29691c8)
